### PR TITLE
修复sys_theme被覆盖问题

### DIFF
--- a/mp-cu/main.js
+++ b/mp-cu/main.js
@@ -234,8 +234,8 @@ export default class ColorUI {
                 setStatusStyle(wx.getSystemInfoSync().theme === 'light' ? 'dark' : 'light')
             })
         } else {
-            wx.setStorageSync('sys_theme', this.config.theme)
-            setStatusStyle(this.config.theme === 'light' ? 'dark' : 'light');
+            wx.setStorageSync('sys_theme', store.state.sys_theme)
+            setStatusStyle(store.state.sys_theme === 'light' ? 'dark' : 'light');
         }
         const originPage = Page
         const originComponent = Component;


### PR DESCRIPTION
问题复现步骤：
①在config/ColorUI.js配置config.theme为light，此时主题为light ②通过ui-change-theme把主题切换为dark，此时主题为dark
③刷新一下页面，storage的sys_theme被覆盖为light，$cuConfig.theme为dark ④再次刷新一下页面，storage的sys_theme为light，$cuConfig.theme为light