### PR TITLE
修复config.theme为auto问题

### DIFF
--- a/mp-cu/main.js
+++ b/mp-cu/main.js
@@ -227,7 +227,7 @@ export default class ColorUI {
             }
         };
         store = CUStoreInit(this.config)
-        if (this.config.theme === 'auto') {
+        if (store.state.sys_theme === 'auto') {
             wx.onThemeChange((res) => {
                 store.setState({sys_theme: 'auto'})
                 wx.setStorageSync('sys_theme', 'auto');


### PR DESCRIPTION
config.theme为auto时，ios切换为light或dark时，锁屏后再解锁屏 或 切后台在进入，自动变回auto